### PR TITLE
Fix small edge case with parsing numbers

### DIFF
--- a/src/lox/Scanner.java
+++ b/src/lox/Scanner.java
@@ -170,7 +170,7 @@ public class Scanner {
     while (!isAtEnd() && isDigit(peek())) advance();
 
     // Look for a fractional part.
-    if (peek() == '.' && isDigit(peekNext())) {
+    if (!isAtEnd() && peek() == '.' && isDigit(peekNext())) {
       // Consume the "."
       advance();
 

--- a/src/lox/ScannerTest.java
+++ b/src/lox/ScannerTest.java
@@ -35,6 +35,6 @@ class ScannerTest {
     List<Token> tokens =  scanner.scanTokens();
 
     assertEquals(2, tokens.size());
-//    assertEquals("STRING \"Hello\" null", tokens.get(0).toStrging());
+    assertEquals("NUMBER 11 null", tokens.get(0).toStrging());
   }
 }


### PR DESCRIPTION
If a source code ends with a number it will fail to parse it due to not checking isAtEnd() and moving current pointer out of source code bounds. To fix it I implemented similar check as in string().